### PR TITLE
Round the number of usecs when dumping

### DIFF
--- a/lib/types/datetime.ex
+++ b/lib/types/datetime.ex
@@ -39,7 +39,7 @@ defmodule Timex.Ecto.DateTime do
   Convert to native Ecto representation
   """
   def dump(%DateTime{year: y, month: m, day: d, hour: h, minute: min, second: s, ms: ms}) do
-    {:ok, {{y, m, d}, {h, min, s, ms * 1_000}}}
+    {:ok, {{y, m, d}, {h, min, s, round(ms * 1_000)}}}
   end
   def dump(_), do: :error
 end


### PR DESCRIPTION
Mariaex at least expects this number to be an integer while `DateTime` structs sometimes have an integer and sometimes a float in their `ms` field.
