### PR TITLE
Bumps required version to 0.14.2

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -30,7 +30,7 @@ defmodule TimexEcto.Mixfile do
   # Type `mix help deps` for more examples and options
   defp deps do
     [{:timex, "~> 0.16.0"},
-     {:ecto, "~> 0.13.1"},
+     {:ecto, "~> 0.14.2"},
      {:earmark, "~> 0.1", only: :dev},
      {:ex_doc, "~> 0.5", only: :dev}]
   end

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,6 @@
 %{"decimal": {:hex, :decimal, "1.1.0"},
   "earmark": {:hex, :earmark, "0.1.17"},
-  "ecto": {:hex, :ecto, "0.13.1"},
+  "ecto": {:hex, :ecto, "0.14.2"},
   "ex_doc": {:hex, :ex_doc, "0.7.3"},
   "poolboy": {:hex, :poolboy, "1.5.1"},
   "timex": {:hex, :timex, "0.16.0"},


### PR DESCRIPTION
As far as I can tell, everything in `timex_ecto` plays nicely with `0.14.2`, but `mix.exs` is currently locked to `0.13.x`
