### PR TITLE
Add link to hexdocs documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,11 @@ iex(3)>
 
 ## Additional Documentation
 
-Documentation for Timex and timex_ecto are available [here](https://timex.readme.io).
+Documentation for Timex and timex_ecto are available
+[here], and on [hexdocs].
+
+[here]: https://timex.readme.io
+[hexdocs]: http://hexdocs.pm/timex_ecto/
 
 ## License
 


### PR DESCRIPTION
Instead of linking only to readme.io, this adds an explicit link to hexdocs since the documentation there is more specific.
