### PR TITLE
Rely on Ecto types when casting to Timex.Ecto types

### DIFF
--- a/lib/types/date.ex
+++ b/lib/types/date.ex
@@ -16,15 +16,14 @@ defmodule Timex.Ecto.Date do
   @doc """
   Handle casting to Timex.Ecto.Date
   """
-  def cast(input) when is_binary(input) do
-    case DateFormat.parse(input, "{ISOdate}") do
-      {:ok, datetime} -> {:ok, datetime}
-      {:error, _}     -> :error
-    end
-  end
   def cast(%DateTime{timezone: nil} = datetime), do: {:ok, %{datetime | :timezone => %TimezoneInfo{}}}
   def cast(%DateTime{} = datetime),              do: {:ok, datetime}
-  def cast(_), do: :error
+  def cast(input) do
+    case Ecto.Date.cast(input) do
+      {:ok, date} -> load({date.year, date.month, date.day})
+      :error -> :error
+    end
+  end
 
   @doc """
   Load from the native Ecto representation

--- a/lib/types/datetime.ex
+++ b/lib/types/datetime.ex
@@ -16,15 +16,14 @@ defmodule Timex.Ecto.DateTime do
   @doc """
   Handle casting to Timex.Ecto.DateTime
   """
-  def cast(input) when is_binary(input) do
-    case DateFormat.parse(input, "{ISO}") do
-      {:ok, datetime} -> {:ok, datetime}
-      {:error, _}     -> :error
-    end
-  end
   def cast(%DateTime{timezone: nil} = datetime), do: {:ok, %{datetime | :timezone => %TimezoneInfo{}}}
   def cast(%DateTime{} = datetime),              do: {:ok, datetime}
-  def cast(_), do: :error
+  def cast(input) do
+    case Ecto.DateTime.cast(input) do
+      {:ok, datetime} -> load({datetime.year, datetime.month, datetime.day}, {datetime.hour, datetime.min, datetime.sec, datetime.usec})
+      :error -> :error
+    end
+  end
 
   @doc """
   Load from the native Ecto representation

--- a/lib/types/datetime.ex
+++ b/lib/types/datetime.ex
@@ -20,7 +20,7 @@ defmodule Timex.Ecto.DateTime do
   def cast(%DateTime{} = datetime),              do: {:ok, datetime}
   def cast(input) do
     case Ecto.DateTime.cast(input) do
-      {:ok, datetime} -> load({datetime.year, datetime.month, datetime.day}, {datetime.hour, datetime.min, datetime.sec, datetime.usec})
+      {:ok, datetime} -> load({{datetime.year, datetime.month, datetime.day}, {datetime.hour, datetime.min, datetime.sec, datetime.usec}})
       :error -> :error
     end
   end

--- a/lib/types/datetimetz.ex
+++ b/lib/types/datetimetz.ex
@@ -38,7 +38,17 @@ defmodule Timex.Ecto.DateTimeWithTimezone do
   """
   def cast(%DateTime{timezone: nil} = datetime), do: {:ok, %{datetime | :timezone => %TimezoneInfo{}}}
   def cast(%DateTime{} = datetime), do: {:ok, datetime}
-  def cast(_), do: :error
+  def cast(input) do
+    case Ecto.DateTimeWithTimezone.cast(input) do
+      {:ok, datetime} ->
+        load({{{datetime.year, datetime.month, datetime.day},
+               {datetime.hour, datetime.min, datetime.sec, datetime.usec}
+              },
+              datetime.timezone
+            }
+      :error -> :error
+    end
+  end
 
   @doc """
   Load from the native Ecto representation

--- a/lib/types/datetimetz.ex
+++ b/lib/types/datetimetz.ex
@@ -45,7 +45,7 @@ defmodule Timex.Ecto.DateTimeWithTimezone do
                {datetime.hour, datetime.min, datetime.sec, datetime.usec}
               },
               datetime.timezone
-            }
+            })
       :error -> :error
     end
   end

--- a/lib/types/time.ex
+++ b/lib/types/time.ex
@@ -26,7 +26,12 @@ defmodule Timex.Ecto.Time do
     end
   end
   def cast({_, _, _} = timestamp), do: {:ok, timestamp}
-  def cast(_), do: :error
+  def cast(input) do
+    case Ecto.Time.cast(input) do
+      {:ok, time} -> load({time.hour, time.minute, time.second, time.usecs})
+      :error -> :error
+    end
+  end
 
   @doc """
   Load from the native Ecto representation


### PR DESCRIPTION
Rely on Ecto's casting functions, which cover and will continue covering more cases. With this, you can use datetime_select (and other date and time related input methods) in a Phoenix.HTML form and the generated changeset will be correctly casted to a Timex type.

This is related to issue #11.
