### PR TITLE
Add DateTime.cast! function to better mimic Ecto

### DIFF
--- a/lib/types/datetime.ex
+++ b/lib/types/datetime.ex
@@ -41,6 +41,16 @@ defmodule Timex.Ecto.DateTime do
   end
 
   @doc """
+  Handle casting to Timex.Ecto.DateTime without returning a tuple
+  """
+  def cast!(input) do
+    case cast(input) do
+      {:ok, datetime} -> datetime
+      :error -> :error
+    end
+  end
+
+  @doc """
   Load from the native Ecto representation
   """
   def load({{year, month, day}, {hour, min, sec, usec}}) do


### PR DESCRIPTION
```
iex(17)> Ecto.DateTime.cast!("2016-02-02T12:30:00Z")
#Ecto.DateTime<2016-02-02T12:30:00Z>

iex(18)> Timex.Ecto.DateTime.cast!("2016-02-02T12:30:00Z")
%Timex.DateTime{calendar: :gregorian, day: 2, hour: 12, millisecond: 0,
 minute: 30, month: 2, second: 0,
 timezone: %Timex.TimezoneInfo{abbreviation: "UTC", from: :min,
  full_name: "UTC", offset_std: 0, offset_utc: 0, until: :max}, year: 2016}

iex(19)> Timex.Ecto.DateTime.cast!(Ecto.DateTime.cast!("2016-02-02T12:30:00Z"))
%Timex.DateTime{calendar: :gregorian, day: 2, hour: 12, millisecond: 0,
 minute: 30, month: 2, second: 0,
 timezone: %Timex.TimezoneInfo{abbreviation: "UTC", from: :min,
  full_name: "UTC", offset_std: 0, offset_utc: 0, until: :max}, year: 2016}
```

So Ecto.DateTime supports casting and returning the casted structs outside of a tuple.
This PR brings Timex.Ecto.DateTime more in line with it.

Seeing as ExMachina doesn't currently support automatically casting iso8601 bit strings, this will make things like seeding factories with datetime attributes a bit nicer.

**Instead of this:**

``` elixir
    MyFactory.create(
      :my_model_type,
      %{
        name: "model_name", 
        created_at: Timex.Ecto.DateTime.cast("2016-02-02T12:30:00Z") |> elem(1),
        updated_at: Timex.Ecto.DateTime.cast("2016-02-02T12:30:00Z") |> elem(1)
      }
    )
```

**or this:**

``` elixir
    {:ok, created_at_time} = Timex.Ecto.DateTime.cast("2016-02-02T12:30:00Z")
    {:ok, updated_at_time} = Timex.Ecto.DateTime.cast("2016-02-02T12:30:00Z")
    MyFactory.create(
      :my_model_type,
      %{
        name: "model_name", 
        created_at: created_at_time,
        updated_at: updated_at_time
      }
    )
```

**We can have this:**

``` elixir
    MyFactory.create(
      :my_model_type,
      %{
        name: "model_name", 
        created_at: Timex.Ecto.DateTime.cast!("2016-02-02T12:30:00Z"),
        updated_at: Timex.Ecto.DateTime.cast!("2016-02-02T12:30:00Z")
      }
    )
```
