### PR TITLE
Fix app name

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ To use timex_ecto with your projects, edit your `mix.exs` file and add it as a d
 
 ```elixir
 def application do
- [ applications: [:timex, ...], ...]
+ [ applications: [:timex_ecto, ...], ...]
 end
 
 defp deps do


### PR DESCRIPTION
Using the current documentation, when I deploy to production I get the following error:

```
16:30:20.380 [error] GenServer #PID<0.314.0> terminating
** (UndefinedFunctionError) undefined function: Timex.Ecto.DateTime.load/1 (module Timex.Ecto.DateTime is not available)
    Timex.Ecto.DateTime.load({{2016, 3, 28}, {21, 35, 50, 0}})
    (ecto) lib/ecto/schema.ex:980: Ecto.Schema.load!/3
    (ecto) lib/ecto/schema.ex:974: anonymous fn/3 in Ecto.Schema.do_load/4
    (elixir) lib/enum.ex:1387: Enum."-reduce/3-lists^foldl/2-0-"/3
    (ecto) lib/ecto/schema.ex:972: Ecto.Schema.do_load/4
    (ecto) lib/ecto/schema.ex:957: Ecto.Schema.__load__/6
    (ecto) lib/ecto/adapters/sql.ex:519: anonymous fn/3 in Ecto.Adapters.SQL.process_row/3
    (elixir) lib/enum.ex:1102: Enum."-map_reduce/3-lists^mapfoldl/2-0-"/3
```

Making this change in my `mix.exs` fixed it.
