### PR TITLE
add autogenerate option parameter to Ecto schema

### DIFF
--- a/lib/model.ex
+++ b/lib/model.ex
@@ -32,8 +32,14 @@ defmodule Timex.Ecto.Timestamps do
 
   @default_timestamps_opts [type: Timex.Ecto.DateTime]
   defmacro __using__(opts) do
+    autogen_args = case Keyword.fetch(opts, :usec) do
+      {:ok, true} -> [:usec]
+      _           -> [:sec]
+    end
+    autogenerate_opts = [autogenerate: {Timex.Ecto.DateTime, :autogenerate, autogen_args}]
+    escaped_opts = opts |> Dict.merge(autogenerate_opts) |> Macro.escape
     quote do
-      @timestamps_opts unquote(Dict.merge(opts, @default_timestamps_opts))
+      @timestamps_opts unquote(Dict.merge(escaped_opts, @default_timestamps_opts))
     end
   end
 end

--- a/lib/types/datetime.ex
+++ b/lib/types/datetime.ex
@@ -67,5 +67,16 @@ defmodule Timex.Ecto.DateTime do
     {:ok, {{y, m, d}, {h, min, s, round(ms * 1_000)}}}
   end
   def dump(_), do: :error
+
+  def autogenerate(precision \\ :sec)
+  def autogenerate(:sec) do
+    {date, {h, m, s}} = :erlang.universaltime
+    load({date,{h, m, s, 0}}) |> elem(1)
+  end
+  def autogenerate(:used) do
+    timestamp = {_,_, usec} = :os.timestamp
+    {date, {h, m, s}} = :calendar.now_to_datetime(timestamp)
+    load({date, {h, m, s, usec}}) |> elem(1)
+  end
 end
 


### PR DESCRIPTION
This fixes a compatibility problem with autogenerated timestamps introduced in Ecto 2.0.0-rc4.
Ecto 2.0.0-rc5 should work correctly after this commit.
#27
