### PR TITLE
Update mix.exs

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -28,7 +28,7 @@ defmodule TimexEcto.Mixfile do
   #
   # Type `mix help deps` for more examples and options
   defp deps do
-    [{:timex, "~> 2.1"},
+    [{:timex, "~> 3.0"},
      {:ecto, "~> 1.1 or ~> 2.0 or ~> 2.0.0-rc3"},
      {:earmark, ">= 0.0.0", only: :dev},
      {:ex_doc, "~> 0.10", only: :dev}]


### PR DESCRIPTION
Bump timex version, without it `override: true` has to be specified on timex.

EDIT: I see now that timex_ecto is not ready yet for timex 3
