### PR TITLE
Updated timex_ecto version in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 Learn how to add `timex_ecto` to your Elixir project and start using it.
 
-**NOTE**: You must use Timex 3.0.2 or greater with timex_ecto 2.x!
+**NOTE**: You must use Timex 3.0.2 or greater with timex_ecto 3.x!
 
 ### Adding timex_ecto To Your Project
 
@@ -20,7 +20,7 @@ end
 
 defp deps do
   [{:timex, "~> 3.0"},
-   {:timex_ecto, "~> 2.0"}]
+   {:timex_ecto, "~> 3.0"}]
 end
 ```
 


### PR DESCRIPTION
Since theres no timex_ecto version 2.x in https://hex.pm/packages/timex_ecto

Lets update the document so it uses version 3.x instead.

cc @bitwalker 
