### PR TITLE
add tests that used to pass in timex_ecto prior to  version 3

### DIFF
--- a/test/types/date_test.exs
+++ b/test/types/date_test.exs
@@ -6,9 +6,19 @@ defmodule Timex.Ecto.Date.Test do
     assert Timex.Ecto.Date.cast(map) == {:ok, Timex.to_date({2016,2,14})}
   end
 
-  test "cast/1 map with castable binaries" do
+  test "cast/1 with a binary in the 'YYYY-MM-DD' format" do
     date = "2016-02-14"
     assert Timex.Ecto.Date.cast(date) == {:ok, Timex.to_date({2016,2,14})}
+  end
+
+  test "cast/1 map with year, month, day as integer values" do
+    map = %{"year" => 2016, "month" => 02, "day" => 14 }
+    assert Timex.Ecto.Date.cast(map) == {:ok, Timex.to_date({2016,2,14})}
+  end
+
+  test "cast/1 map with year, month, day as binary values" do
+    map = %{"year" => "2016", "month" => "02", "day" => "14" }
+    assert Timex.Ecto.Date.cast(map) == {:ok, Timex.to_date({2016,2,14})}
   end
 
 end


### PR DESCRIPTION
this is to prevent the error described in #42 

these tests will pass with timex 3.0.7 because of https://github.com/bitwalker/timex/issues/208
