### PR TITLE
Adding support for Ecto.Date & cleaning up documentation.

### DIFF
--- a/lib/types/date.ex
+++ b/lib/types/date.ex
@@ -36,9 +36,26 @@ defmodule Timex.Ecto.Date do
   end
 
   @doc """
-  Load from the native Ecto representation
+  Creates a Timex.Date from from a passed in date.
+
+  Returns `{:ok, Timex.Date}` when successful.
+
+  Returns `:error` if the type passed in is either not an erl date nor Ecto.Date
+
+  ## Examples
+     Using an Ecto.Date:
+
+      iex> Ecto.Date.from_erl({2017, 2, 1})
+      ...> |> Timex.Ecto.Date.load
+      {:ok, ~D[2017-02-01]}
+
+    Using an erl date:
+
+      iex> Timex.Ecto.Date.load({2017, 2, 1})
+      {:ok, ~D[2017-02-01]}
   """
   def load({_year, _month, _day} = date), do: {:ok, Timex.to_date(date)}
+  def load(%Ecto.Date{} = date), do: {:ok, Ecto.Date.to_erl(date) |> Timex.to_date}
   def load(_), do: :error
 
   @doc """

--- a/test/types/date_test.exs
+++ b/test/types/date_test.exs
@@ -1,5 +1,6 @@
 defmodule Timex.Ecto.Date.Test do
   use ExUnit.Case
+  doctest Timex.Ecto.Date
 
   test "cast/1 map with calendar, year, month, day" do
     map = %{"calendar" => nil, "year" => 2016, "month" => 02, "day" => 14 }
@@ -21,4 +22,8 @@ defmodule Timex.Ecto.Date.Test do
     assert Timex.Ecto.Date.cast(map) == {:ok, Timex.to_date({2016,2,14})}
   end
 
+  test "load/1 with an Ecto.Date should return a Timex date" do
+    ecto_date = Ecto.Date.from_erl({2017, 2, 12})
+    assert Timex.Ecto.Date.load(ecto_date) == {:ok, Timex.to_date({2017, 2, 12})}
+  end
 end


### PR DESCRIPTION
This makes it so that `Timex.Ecto.Date.load` can handle an `Ecto.Date` or an erl date. 

Cleaned up the documentation for the function, and added the `doctest` to the `Timex.Ecto.Date.Test` module.