### PR TITLE
Put EctoTest.Repo so that mix ecto.create will work

### DIFF
--- a/lib/test/repo.ex
+++ b/lib/test/repo.ex
@@ -1,0 +1,3 @@
+defmodule EctoTest.Repo do
+  use Ecto.Repo, otp_app: :timex_ecto
+end

--- a/test/timex_ecto_test.exs
+++ b/test/timex_ecto_test.exs
@@ -1,7 +1,4 @@
 if Code.ensure_loaded?(Postgrex) do
-  defmodule EctoTest.Repo do
-    use Ecto.Repo, otp_app: :timex_ecto
-  end
 
   defmodule EctoTest.User do
     use Ecto.Schema

--- a/test/timex_ecto_test.exs
+++ b/test/timex_ecto_test.exs
@@ -104,11 +104,15 @@ if Code.ensure_loaded?(Postgrex) do
         from u in User,
         select: u
 
-      [%User{date_test: ^date,
-             time_test: ^time,
-             datetime_test: ^datetime,
-             datetimetz_test: ^datetimetz,
-             timestamptz_test: ^timestamptz}] = Repo.all(query)
+      [same_user] = Repo.all(query)
+      assert same_user.name == "Paul"
+      assert same_user.date_test == date
+      assert same_user.time_test == time
+
+      # To avoid microsecond mismatches on a CI server
+      assert same_user.datetime_test |> DateTime.to_string == datetime |> DateTime.to_string
+      assert same_user.datetimetz_test |> DateTime.to_string == datetimetz |> DateTime.to_string
+      assert same_user.timestamptz_test |> DateTime.to_string == timestamptz |> DateTime.to_string
 
       query =
         from u in User,


### PR DESCRIPTION

Failing tests urk me... so I hopped back on.  I actually "fixed" this locally, but then undid it (as I didn't love the solution, but didn't realize it was necessary to make it work in "more" environments).

If the repo isn't available, then `mix ecto.create` gets confused.

```
18:40 timex_ecto (f/test_repo)$ MIX_ENV=test mix ecto.create
Compiling 1 file (.ex)
Generated timex_ecto app
** (Mix) Could not load EctoTest.Repo, error: :nofile. Please configure your app accordingly or pass a repo with the -r option.
```

I was not able to be `-r` to work.

With this change, we can run `MIX_ENV=test mix ecto.create`.  The travis config should now work out of the box as the MIX_ENV is always test.