### PR TITLE
Missing last argument in first Ecto example

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ defmodule User do
   use Ecto.Schema
 
   @timestamps_opts [type: Timex.Ecto.TimestampWithTimezone,
-                    autogenerate: {Timex.Ecto.TimestampWithTimezone, :autogenerate}]
+                    autogenerate: {Timex.Ecto.TimestampWithTimezone, :autogenerate, []}]
 
   schema "users" do
     field :name, :string
@@ -72,7 +72,7 @@ defmodule User do
 end
 ```
 
-### ~~Using Timex with Ecto's `timestamps` macro~~
+### Using Timex with Ecto's `timestamps` macro
 
 Super simple! Your timestamps will now be `Timex.Ecto.DateTime` structs instead of `Ecto.DateTime` structs.
 
@@ -89,7 +89,7 @@ defmodule User do
 end
 ```
 
-### ~~Using with Phoenix~~
+### Using with Phoenix
 
 Phoenix allows you to apply defaults globally to Ecto models via `web/web.ex` by changing the `model` function like so:
 


### PR DESCRIPTION
Hi,

This just cost me 10 minutes or so :man_facepalming:. Especially because it doesn't error (guess `autogenerate/0` is called), but instead just comes up with `NULL` in the timestamp columns.

Also, I think these sections are valid again? The `DEPRECATED` was removed before, so I guess the strikethrough is not intended.

Best,
malte