### PR TITLE
Fix embeds for Timex.Ecto.Time

### DIFF
--- a/lib/types/time.ex
+++ b/lib/types/time.ex
@@ -29,8 +29,7 @@ defmodule Timex.Ecto.Time do
   end
   # Support embeds_one/embeds_many
   def cast(%{"megaseconds" => m, "seconds" => s, "microseconds" => us}) do
-    clock = Duration.to_clock({m,s,us})
-    load(clock)
+    {:ok, Duration.from_erl({m,s,us})}
   end
   def cast(%{"hour" => h, "minute" => mm, "second" => s, "ms" => ms}) do
     load({h, mm, s, ms * 1_000})


### PR DESCRIPTION
** (FunctionClauseError) no function clause matching in Timex.Duration.to_clock/1

    The following arguments were given to Timex.Duration.to_clock/1:

        # 1
        {0, -900, 0}

    Attempted function clauses (showing 1 out of 1):

        def to_clock(%Timex.Duration{megaseconds: mega, seconds: sec, microseconds: micro})

    (timex) lib/time/duration.ex:157: Timex.Duration.to_clock/1
    (timex_ecto) lib/types/time.ex:32: Timex.Ecto.Time.cast/1